### PR TITLE
Add parsepdf structured output

### DIFF
--- a/src/paperazzi/structured_output/parsepdf/__init__.py
+++ b/src/paperazzi/structured_output/parsepdf/__init__.py
@@ -1,0 +1,1 @@
+from . import model

--- a/src/paperazzi/structured_output/parsepdf/model.py
+++ b/src/paperazzi/structured_output/parsepdf/model.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from packaging.version import Version
+
+from paperazzi.structured_output.utils import Metadata
+
+METADATA = Metadata(model_id=Path(__file__).parent.name, model_version=Version("0.0.0"))

--- a/src/paperazzi/structured_output/parsepdf/model_v0.py
+++ b/src/paperazzi/structured_output/parsepdf/model_v0.py
@@ -1,0 +1,5 @@
+# This model aims to extract Deep Learning Models, Datasets and Libraries from a
+# research paper
+# Very bad practice but we will allow it here since it acts like a proxy to the
+# latest model version and nothing else is imported
+from .model import *

--- a/src/paperazzi/structured_output/parsepdf/ocr.py
+++ b/src/paperazzi/structured_output/parsepdf/ocr.py
@@ -1,0 +1,67 @@
+import argparse
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from paperazzi import CFG
+from paperazzi.platforms.openai.utils import Message
+from paperazzi.platforms.utils import get_platform
+from paperazzi.structured_output.utils import get_structured_output, make_disk_store
+from paperazzi.utils import PaperTxt, disk_cache
+from paperazzi.utils import disk_store as disk_store_decorator
+
+PROG = f"{Path(__file__).stem.replace('_', '-')}"
+
+
+def paper_make_key(paper: PaperTxt):
+    return lambda a, k: paper.id
+
+
+def main(argv: list = None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--paperoni",
+        nargs="*",
+        type=Path,
+        default=[],
+        help="Paperoni json report of papers to analyse",
+    )
+    options = parser.parse_args(argv)
+
+    paperoni = sum([json.loads(_p.read_text()) for _p in options.paperoni], [])
+
+    metadata = get_structured_output().METADATA.model_copy()
+    metadata.llm_model = CFG[CFG.platform.select].model
+
+    disk_store = make_disk_store(metadata)
+
+    papers = [PaperTxt(p, disk_store=disk_store) for p in paperoni]
+
+    client = get_platform().client()
+    disk_store_prompt = disk_store_decorator(
+        disk_cache(get_platform().ocr),
+        disk_store,
+        serializer=get_platform().OCRResponseSerializer,
+    )
+
+    LOG_FILE = CFG.dir.log / datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    logging.basicConfig(
+        filename=LOG_FILE.with_suffix(
+            f".{PROG}.{metadata.model_id}.{disk_store.prefix}.{metadata.model_id}.dbg"
+        ),
+        level=logging.DEBUG,
+        force=True,
+    )
+
+    for paper in papers:
+        messages = [
+            Message(type="application/pdf", prompt=paper.pdfs[0]),
+        ]
+
+        prompt = disk_store_prompt.update(make_key=paper_make_key(paper), index=0)
+        prompt(client=client, messages=messages, model=metadata.llm_model)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/paperazzi/structured_output/utils.py
+++ b/src/paperazzi/structured_output/utils.py
@@ -46,9 +46,17 @@ def make_disk_store(
     # choice.
     prefix = get_platform(prefix).CODE.lower()
     if metadata.llm_model:
-        # Remove underscores from the LLM model name to ease parsing of the
+        # Remove underscores from the LLM model name to simplify parsing of the
         # filename (prefix_id_index)
-        prefix = "-".join([prefix, metadata.llm_model.replace("_", "")])
+        prefix = "-".join(
+            [
+                prefix,
+                metadata.llm_model.replace("models", "")
+                .replace("model", "")
+                .replace("_", "")
+                .replace("/", ""),
+            ]
+        )
 
     return DiskStore(
         cache_dir=cache_dir,


### PR DESCRIPTION
### What change is being made?

Add a new `parsepdf` module within the `structured_output` package, including an `ocr` components to extract convert pdf to markdown.